### PR TITLE
Auto asignacion a PR team como reviewer

### DIFF
--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -1,0 +1,18 @@
+#Auto asignar equipo como reviewers en pull requests 
+name: "Auto Assign Reviewers"
+on:  
+  pull_request:
+    types: [opened, ready_for_review]
+     
+jobs:
+  assign-reviewers:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Assign Team and Persons"
+      uses: rowi1de/auto-assign-review-teams@v1.0.1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        teams: "site-pr-approval"       # only works for GitHub Organisation/Teams
+#        persons: ""                    # add individual persons here 
+        include-draft: false            # Draft PRs will be skipped (default: false)
+        skip-with-manual-reviewers: 2   # Skip this action, if the number of reviwers was already assigned (default: 0)


### PR DESCRIPTION
Encontré este action que permite asignar equipos como reviewers automáticamente.