### PR TITLE
Fix: La nueva version de hugo rompe la pipeline de las birras

### DIFF
--- a/.github/workflows/programar_adminbirras.yml
+++ b/.github/workflows/programar_adminbirras.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Setup Hugo
       uses: peaceiris/actions-hugo@v2
       with:
-        hugo-version: 'latest'
+        hugo-version: '0.88.1'
     - name: Run a one-line script
       run: bash -x ./itfloss create adminbirras -f "${{ github.event.inputs.fecha }}" -l "${{ github.event.inputs.lugar }}" -t "${{ github.event.inputs.titulo }}" -n "$(date +%F)"
     - name: switching from HTTPS to SSH


### PR DESCRIPTION

v0.89.2 Latest

This is a bug-fix release with a couple of important fixes.

    Fix path resolution in hugo new 2b01c85d @bep #9129
    deps: Upgrade github.com/yuin/goldmark v1.4.2 => v1.4.3 c09f5c5f @bep #9137

Cambio el stdout del commando "hugo new --kind adminbirras eventos/adminbirras/FECHA.md" y rompe la automatizacion. setie la version anterior en vez de latest por ahora
https://github.com/gohugoio/hugo/commit/2b01c85d14102353015cf6860d30be3d92964495