### PR TITLE
Create rebuild.yml

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -1,0 +1,20 @@
+# File: .github/workflows/rebuild.yml
+name: 'GitHub Pages Re-Build'
+# description: 'Rebuilds GitHub Pages using Pages API'
+on:
+  schedule:
+    - cron:  '0 4 1 1 *' # Runs At 04am (it use UTC time) on day-of-month 1 in January
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger GitHub pages rebuild
+        run: |
+          curl --fail --request POST \
+            --url https://api.github.com/repos/${{ github.repository }}/pages/builds \
+            --header "Authorization: Bearer $USER_TOKEN"
+        env:
+          # You must create a personal token with repo access as GitHub does
+          # not yet support server-to-server page builds.
+          USER_TOKEN: ${{ secrets.USER_TOKEN }}


### PR DESCRIPTION
Rebuilds GitHub Pages using Pages API, in order to force update "copyright" date in the footer, as apparently it change at the build.
Will run in a new year without the need to commit any real changes or new post.